### PR TITLE
Refresh: cross-link clusterstuck.sh (homelab + agent swarm)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
     time I make them just because I want them to exist. Day job is mostly AI/ML
     infrastructure and systems stuff - getting LLMs to actually run, plus the
     compilers and distributed-systems plumbing underneath - but the version of
-    me that lives on this website is the fun one.</p>
+    me that lives on this website is the fun one. I also run a self-hosted
+    homelab and a little swarm of AI agents that runs it - that lives at
+    <a href="https://clusterstuck.sh">clusterstuck.sh</a>.</p>
     <p>This website is a junkyard (and also a graveyard) of all the projects I
     have ever worked on, completed or otherwise. It is the unfakeable layer -
     the stuff I built because I wanted it to exist. At the very least, this
@@ -31,7 +33,15 @@
     - reach out if you need a talented reverse-engineer/programmer for
     your projects. I also did speedruns, but I ran too fast and injured my gaming fingers.</p>
     </header>
-    
+
+    <section>
+    <h2>homelab</h2>
+    <aside>the fleet and the swarm that runs it</aside>
+    <ul>
+        <li><a href="https://clusterstuck.sh">Clusterstuck - a self-hosted homelab run by an AI agent swarm</a>, <i>2026-present</i></li>
+    </ul>
+    </section>
+
     <section>
     <h2>projects</h2>
     <aside>completed things that i'm always ready to return to</aside>
@@ -96,6 +106,7 @@
             <li><a href="https://t.me/hs_ray">Telegram</a></li>
             <li><a href="mailto:i@yar.sh">E-mail</a></li>
             <li><a href="https://github.com/yar-sh">GitHub</a></li>
+	    <li><a href="https://clusterstuck.sh">clusterstuck.sh</a></li>
 	    <li><a href="https://www.youtube.com/@yar_sh">YouTube</a></li>
 	    <li><a href="https://www.linkedin.com/in/yaroslav-mikhaylik/">LinkedIn</a></li>
         </ul>


### PR DESCRIPTION
DRAFT - do not merge. github.io auto-publishes from the default branch (master), so this stays on a feature branch until the operator reviews and merges.

Adds cross-links from the personal site to **clusterstuck.sh** (the home of the self-hosted homelab + AI agent swarm):
- a sentence in the header intro
- a new 'homelab' section (first section)
- a footer link in the wide list

Preserved: existing personal content/voice/style, the pre-existing keepandroidopen.org banner script, and no resume/CV link invented (none exists). No opsec-sensitive identifiers added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)